### PR TITLE
Fix for GCC6

### DIFF
--- a/pkg-config-0.29/glib/glib/gdate.c
+++ b/pkg-config-0.29/glib/glib/gdate.c
@@ -2439,6 +2439,9 @@ win32_strftime_helper (const GDate     *d,
  *
  * Returns: number of characters written to the buffer, or 0 the buffer was too small
  */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+
 gsize     
 g_date_strftime (gchar       *s, 
                  gsize        slen, 
@@ -2549,3 +2552,5 @@ g_date_strftime (gchar       *s,
   return retval;
 #endif
 }
+
+#pragma GCC diagnostic pop


### PR DESCRIPTION
Merged patch from two commits to enable problem of autotools with GCC6
    gdate: Suppress string format literal warning
    gdate: Move warning pragma outside of function
    https://bugzilla.gnome.org/761550
